### PR TITLE
Create integration-issues.yml

### DIFF
--- a/.github/workflows/integration-issues.yml
+++ b/.github/workflows/integration-issues.yml
@@ -1,0 +1,23 @@
+---
+# Automatically adds issues to the Integration Github project
+# if the issue is tagged with `integration`
+
+name: Add integration tasks to Integration project
+
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add integration issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@5b15b1a619153d251d9affe56d0b5f291f679f21
+        with:
+          project-url: https://github.com/orgs/DARPA-ASKEM/projects/5
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: integration
+          label-operator: OR


### PR DESCRIPTION
This github action will automatically push issues labelled `integration` to the DARPA-ASKEM Integration Project page.

It does require adding a secret to the repo which I can do once this is merged.